### PR TITLE
exec_query's bind parameter defaults to [] instead of nil

### DIFF
--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -24,7 +24,7 @@ module Marginalia
       execute_without_marginalia("#{sql} /*#{Marginalia::Comment.to_s}*/", name)
     end
 
-    def exec_query_with_marginalia(sql, name = nil, binds = nil)
+    def exec_query_with_marginalia(sql, name = nil, binds = [])
       Marginalia::Comment.update! if Marginalia::Comment.components.include? :line
       exec_query_without_marginalia("#{sql} /*#{Marginalia::Comment.to_s}*/", name, binds)
     end


### PR DESCRIPTION
So "bind" is nil, then when you pass it down to exec_query, it calls "bind.empty?", which throws an error since bind is nil. It looks like the default value for exec_query's bind parameter is [] in ActiveRecord, so I just changed it to that.

For example:
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L806
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb#L281
